### PR TITLE
Add martinisoft to missing FreeBSD platform

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -108,3 +108,11 @@ The specific components of Chef related to a given platform - including (but not
 
 * [Joshua Timberman](https://github.com/jtimberman)
 * [Tyler Ball](https://github.com/tyler-ball)
+
+## FreeBSD
+
+### Lieutenant
+
+### Maintainers
+
+* [Aaron Kalin](https://github.com/martinisoft)


### PR DESCRIPTION
This adds me (martinisoft) as a maintainer for FreeBSD officially. From what I can gather, this was informally decided upon with past Chef Developer meetings in IRC and as far as I know I already have commit bit with the freebsd cookbook.