### PR TITLE
Fail execute test if it takes too long

### DIFF
--- a/spec/functional/resource/execute_spec.rb
+++ b/spec/functional/resource/execute_spec.rb
@@ -18,6 +18,7 @@
 
 require 'spec_helper'
 require 'functional/resource/base'
+require 'timeout'
 
 describe Chef::Resource::Execute do
   let(:resource) {
@@ -111,8 +112,10 @@ describe Chef::Resource::Execute do
   end
 
   it "times out when a timeout is set on the resource" do
-    resource.command %{ruby -e 'sleep 600'}
-    resource.timeout 0.1
-    expect { resource.run_action(:run) }.to raise_error(Mixlib::ShellOut::CommandTimeout)
+    Timeout::timeout(5) do
+      resource.command %{ruby -e 'sleep 600'}
+      resource.timeout 0.1
+      expect { resource.run_action(:run) }.to raise_error(Mixlib::ShellOut::CommandTimeout)
+    end
   end
 end


### PR DESCRIPTION
Added a check to see how long executing sleep 600 with a timeout of 0.1 takes, so it is broken on windows. Disable the broken test.

These can be renabled with our next release of mixlib-shellout

Knowing 10 mins are being added to each run is annoying.

cc @opscode/client-engineers 