### PR TITLE
correct filters for MacPorts package provider

### DIFF
--- a/lib/chef/provider/package/macports.rb
+++ b/lib/chef/provider/package/macports.rb
@@ -3,7 +3,7 @@ class Chef
     class Package
       class Macports < Chef::Provider::Package
 
-        provides :macports_package, os: "mac_os_x"
+        provides :macports_package, os: "darwin"
 
         def load_current_resource
           @current_resource = Chef::Resource::Package.new(@new_resource.name)

--- a/lib/chef/provider/package/macports.rb
+++ b/lib/chef/provider/package/macports.rb
@@ -3,7 +3,7 @@ class Chef
     class Package
       class Macports < Chef::Provider::Package
 
-        provides :macports_package, os: "darwin"
+        provides :macports_package
 
         def load_current_resource
           @current_resource = Chef::Resource::Package.new(@new_resource.name)

--- a/lib/chef/resource/macports_package.rb
+++ b/lib/chef/resource/macports_package.rb
@@ -20,7 +20,7 @@ class Chef
   class Resource
     class MacportsPackage < Chef::Resource::Package
 
-      provides :macports_package, os: "mac_os_x"
+      provides :macports_package, os: "darwin"
 
       def initialize(name, run_context=nil)
         super

--- a/lib/chef/resource/macports_package.rb
+++ b/lib/chef/resource/macports_package.rb
@@ -20,7 +20,7 @@ class Chef
   class Resource
     class MacportsPackage < Chef::Resource::Package
 
-      provides :macports_package, os: "darwin"
+      provides :macports_package
 
       def initialize(name, run_context=nil)
         super

--- a/spec/unit/provider_resolver_spec.rb
+++ b/spec/unit/provider_resolver_spec.rb
@@ -511,10 +511,11 @@ describe Chef::ProviderResolver do
 
       supported_providers = [
         :apt_package, :bash, :breakpoint, :chef_gem, :cookbook_file, :csh, :deploy,
-        :deploy_revision, :directory, :dpkg_package, :easy_install_package,
-        :erl_call, :execute, :file, :gem_package, :git, :http_request, :link, :log, :pacman_package, :paludis_package,
-        :perl, :python, :remote_directory, :route, :rpm_package, :ruby, :ruby_block, :script,
-        :subversion, :template, :timestamped_deploy, :whyrun_safe_ruby_block, :yum_package, :homebrew_package,
+        :deploy_revision, :directory, :dpkg_package, :easy_install_package, :erl_call,
+        :execute, :file, :gem_package, :git, :homebrew_package, :http_request, :link,
+        :log, :macports_package, :pacman_package, :paludis_package, :perl, :python,
+        :remote_directory, :route, :rpm_package, :ruby, :ruby_block, :script, :subversion,
+        :template, :timestamped_deploy, :whyrun_safe_ruby_block, :yum_package,
       ]
 
       supported_providers.each do |static_resource|
@@ -530,9 +531,8 @@ describe Chef::ProviderResolver do
       end
 
       unsupported_providers = [
-        :bff_package, :dsc_script, :ips_package, :macports_package,
-        :smartos_package, :solaris_package, :windows_package,
-        :windows_service,
+        :bff_package, :dsc_script, :ips_package, :smartos_package,
+        :solaris_package, :windows_package, :windows_service,
       ]
 
       unsupported_providers.each do |static_resource|


### PR DESCRIPTION
macports needs to provide macports_package to `darwin`, not `mac_os_x`. `mac_os_x` is the platform, `darwin` is the OS.
This resolves #2691. 
@jaymzh will do the merge so it's under his CCLA.