### PR TITLE
Macports provider - provide package

### DIFF
--- a/lib/chef/platform/provider_priority_map.rb
+++ b/lib/chef/platform/provider_priority_map.rb
@@ -66,6 +66,7 @@ class Chef
         #
 
         priority :service, Chef::Provider::Service::Macosx, os: "darwin"
+        priority :package, Chef::Provider::Package::Homebrew, os: "darwin"
       end
 
       def priority_map

--- a/lib/chef/provider/package/macports.rb
+++ b/lib/chef/provider/package/macports.rb
@@ -4,6 +4,7 @@ class Chef
       class Macports < Chef::Provider::Package
 
         provides :macports_package
+        provides :package, os: "darwin"
 
         def load_current_resource
           @current_resource = Chef::Resource::Package.new(@new_resource.name)

--- a/lib/chef/resource/macports_package.rb
+++ b/lib/chef/resource/macports_package.rb
@@ -21,6 +21,7 @@ class Chef
     class MacportsPackage < Chef::Resource::Package
 
       provides :macports_package
+      provides :package, os: "darwin"
 
       def initialize(name, run_context=nil)
         super


### PR DESCRIPTION
The MacPorts provider should provide package so that you can change the
precedence in provider mappings, with a statement like this:

  Chef::Platform::ProviderPriorityMap.instance.priority(
    :package, Chef::Provider::Package::Macports, :os => 'darwin'
  )

This resolves #2690. 
@jaymzh will do the merge so it falls under his CCLA.