### PR TITLE
bugfix dscl provider

### DIFF
--- a/lib/chef/provider/user/dscl.rb
+++ b/lib/chef/provider/user/dscl.rb
@@ -239,8 +239,16 @@ user password using shadow hash.")
         #
         def uid_used?(uid)
           return false unless uid
-          users_uids = run_dscl("list /Users uid")
-          !! ( users_uids =~ Regexp.new("#{Regexp.escape(uid.to_s)}\n") )
+          users_uids = run_dscl("list /Users uid").split("\n")
+          uid_map = users_uids.inject({}) do |tmap, tuid|
+            x = tuid.split
+            tmap[x[1]] = x[0]
+            tmap
+          end
+          if uid_map[uid.to_s]
+            return true unless uid_map[uid.to_s] == @new_resource.username.to_s
+          end
+          return false
         end
 
         #
@@ -535,7 +543,7 @@ user password using shadow hash.")
 
         # A simple map of Chef's terms to DSCL's terms.
         DSCL_PROPERTY_MAP = {
-          :uid => "generateduid",
+          :uid => "uid",
           :gid => "gid",
           :home => "home",
           :shell => "shell",

--- a/lib/chef/provider/user/dscl.rb
+++ b/lib/chef/provider/user/dscl.rb
@@ -246,7 +246,9 @@ user password using shadow hash.")
             tmap
           end
           if uid_map[uid.to_s]
-            return true unless uid_map[uid.to_s] == @new_resource.username.to_s
+            unless uid_map[uid.to_s] == @new_resource.username.to_s
+              return true
+            end
           end
           return false
         end

--- a/spec/unit/provider/user/dscl_spec.rb
+++ b/spec/unit/provider/user/dscl_spec.rb
@@ -422,7 +422,7 @@ ea18e18b720e358e7fbe3cfbeaa561456f6ba008937a30"
         it "collects the user data correctly" do
           provider.load_current_resource
           expect(provider.current_resource.comment).to eq("vagrant")
-          expect(provider.current_resource.uid).to eq("11112222-3333-4444-AAAA-BBBBCCCCDDDD")
+          expect(provider.current_resource.uid).to eq("501")
           expect(provider.current_resource.gid).to eq("80")
           expect(provider.current_resource.home).to eq("/Users/vagrant")
           expect(provider.current_resource.shell).to eq("/bin/bash")
@@ -487,7 +487,7 @@ ea18e18b720e358e7fbe3cfbeaa561456f6ba008937a30"
         it "collects the user data correctly" do
           provider.load_current_resource
           expect(provider.current_resource.comment).to eq("vagrant")
-          expect(provider.current_resource.uid).to eq("11112222-3333-4444-AAAA-BBBBCCCCDDDD")
+          expect(provider.current_resource.uid).to eq("501")
           expect(provider.current_resource.gid).to eq("80")
           expect(provider.current_resource.home).to eq("/Users/vagrant")
           expect(provider.current_resource.shell).to eq("/bin/bash")
@@ -513,7 +513,7 @@ e68d1f9821b26689312366")
         it "collects the user data correctly" do
           provider.load_current_resource
           expect(provider.current_resource.comment).to eq("vagrant")
-          expect(provider.current_resource.uid).to eq("11112222-3333-4444-AAAA-BBBBCCCCDDDD")
+          expect(provider.current_resource.uid).to eq("501")
           expect(provider.current_resource.gid).to eq("80")
           expect(provider.current_resource.home).to eq("/Users/vagrant")
           expect(provider.current_resource.shell).to eq("/bin/bash")
@@ -551,7 +551,7 @@ ea18e18b720e358e7fbe3cfbeaa561456f6ba008937a30")
         it "collects the user data correctly" do
           provider.load_current_resource
           expect(provider.current_resource.comment).to eq("vagrant")
-          expect(provider.current_resource.uid).to eq("11112222-3333-4444-AAAA-BBBBCCCCDDDD")
+          expect(provider.current_resource.uid).to eq("501")
           expect(provider.current_resource.gid).to eq("80")
           expect(provider.current_resource.home).to eq("/Users/vagrant")
           expect(provider.current_resource.shell).to eq("/bin/bash")


### PR DESCRIPTION
We need to compare with the UID, not a GUID. So we need to map the
correct field for comparison.

Also fix a bug in determining used uids.

This fixes this exception when the specified uid is actually in use by the
correct user:

    Chef::Exceptions::RequestedUIDUnavailable: uid 48 is already in use

This resolves #2667.
@jaymzh will do the merge so it falls under his CCLA.