### PR TITLE
OS X user provider - fix exception if no salt is found

### DIFF
--- a/lib/chef/provider/user/dscl.rb
+++ b/lib/chef/provider/user/dscl.rb
@@ -504,7 +504,11 @@ user password using shadow hash.")
             # password to be updated.
             return true if salted_sha512?(@current_resource.password)
 
+            # Some system users don't have salts; this can happen if the system is
+            # upgraded and the user hasn't logged in yet. In this case, we will force
+            # the password to be updated.
             return true if @current_resource.salt.nil?
+
             if salted_sha512_pbkdf2?(@new_resource.password)
               diverged?(:password) || diverged?(:salt) || diverged?(:iterations)
             else

--- a/lib/chef/provider/user/dscl.rb
+++ b/lib/chef/provider/user/dscl.rb
@@ -504,6 +504,7 @@ user password using shadow hash.")
             # password to be updated.
             return true if salted_sha512?(@current_resource.password)
 
+            return true if @current_resource.salt.nil?
             if salted_sha512_pbkdf2?(@new_resource.password)
               diverged?(:password) || diverged?(:salt) || diverged?(:iterations)
             else

--- a/spec/unit/provider/user/dscl_spec.rb
+++ b/spec/unit/provider/user/dscl_spec.rb
@@ -610,6 +610,14 @@ ea18e18b720e358e7fbe3cfbeaa561456f6ba008937a30")
             expect(provider.diverged_password?).to be_truthy
           end
         end
+
+        describe "when salt isn't found" do
+          it "diverged_password? should report true" do
+            provider.load_current_resource
+            provider.current_resource.salt(nil)
+            expect(provider.diverged_password?).to be_truthy
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Some system users don't have salts. This exception is fixed by this
commit:

    # in `convert_to_binary':
    NoMethodError: undefined method `size' for nil:NilClass

@jaymzh will merge this so it falls under his CCLA.