### PR TITLE
add forcing of LANG and LANGUAGE env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * Cleaned up script and execute provider + specs
 * Added deprecation warnings around the use of command attribute in script resources
 * Audit mode feature added - see the RELEASE_NOTES for details
+* shell_out now sets `LANGUAGE` and `LANG` to the `Chef::Config[:internal_locale]` in addition to `LC_ALL` forcing
 
 ## 12.0.3
 * [**Phil Dibowitz**](https://github.com/jaymzh):

--- a/lib/chef/mixin/shell_out.rb
+++ b/lib/chef/mixin/shell_out.rb
@@ -36,9 +36,15 @@ class Chef
           options[env_key] ||= {}
           options[env_key] = options[env_key].dup
           options[env_key]['LC_ALL'] ||= Chef::Config[:internal_locale] unless options[env_key].has_key?('LC_ALL')
+          options[env_key]['LANGUAGE'] ||= Chef::Config[:internal_locale] unless options[env_key].has_key?('LANGUAGE')
+          options[env_key]['LANG'] ||= Chef::Config[:internal_locale] unless options[env_key].has_key?('LANG')
           args << options
         else
-          args << { :environment => { 'LC_ALL' => Chef::Config[:internal_locale] } }
+          args << { :environment => {
+            'LC_ALL' => Chef::Config[:internal_locale],
+            'LANGUAGE' => Chef::Config[:internal_locale],
+            'LANG' => Chef::Config[:internal_locale],
+          } }
         end
 
         shell_out_command(*args)

--- a/spec/unit/mixin/shell_out_spec.rb
+++ b/spec/unit/mixin/shell_out_spec.rb
@@ -44,7 +44,7 @@ describe Chef::Mixin::ShellOut do
 
     context 'without deprecated options' do
       let(:options) { { :environment => environment } }
-      let(:environment) { { 'LC_ALL' => 'C' } }
+      let(:environment) { { 'LC_ALL' => 'C', 'LANG' => 'C', 'LANGUAGE' => 'C' } }
 
       it 'should not edit command args' do
         is_expected.to eql(command_args)
@@ -124,13 +124,13 @@ describe Chef::Mixin::ShellOut do
       describe "when the last argument is a Hash" do
         describe "and environment is an option" do
           it "should not change environment['LC_ALL'] when set to nil" do
-            options = { :environment => { 'LC_ALL' => nil } }
+            options = { :environment => { 'LC_ALL' => nil, 'LANGUAGE' => nil, 'LANG' => nil } }
             expect(shell_out_obj).to receive(:shell_out_command).with(cmd, options).and_return(true)
             shell_out_obj.shell_out(cmd, options)
           end
 
           it "should not change environment['LC_ALL'] when set to non-nil" do
-            options = { :environment => { 'LC_ALL' => 'en_US.UTF-8' } }
+            options = { :environment => { 'LC_ALL' => 'en_US.UTF-8', 'LANGUAGE' => 'en_US.UTF-8', 'LANG' => 'en_US.UTF-8' } }
             expect(shell_out_obj).to receive(:shell_out_command).with(cmd, options).and_return(true)
             shell_out_obj.shell_out(cmd, options)
           end
@@ -138,7 +138,12 @@ describe Chef::Mixin::ShellOut do
           it "should set environment['LC_ALL'] to 'en_US.UTF-8' when 'LC_ALL' not present" do
             options = { :environment => { 'HOME' => '/Users/morty' } }
             expect(shell_out_obj).to receive(:shell_out_command).with(cmd, {
-              :environment => { 'HOME' => '/Users/morty', 'LC_ALL' => Chef::Config[:internal_locale] },
+              :environment => {
+                'HOME'     => '/Users/morty',
+                'LC_ALL'   => Chef::Config[:internal_locale],
+                'LANG'     => Chef::Config[:internal_locale],
+                'LANGUAGE' => Chef::Config[:internal_locale],
+              },
             }).and_return(true)
             shell_out_obj.shell_out(cmd, options)
           end
@@ -146,7 +151,12 @@ describe Chef::Mixin::ShellOut do
           it "should not mutate the options hash when it adds LC_ALL" do
             options = { :environment => { 'HOME' => '/Users/morty' } }
             expect(shell_out_obj).to receive(:shell_out_command).with(cmd, {
-              :environment => { 'HOME' => '/Users/morty', 'LC_ALL' => Chef::Config[:internal_locale] },
+              :environment => {
+                'HOME'     => '/Users/morty',
+                'LC_ALL'   => Chef::Config[:internal_locale],
+                'LANG'     => Chef::Config[:internal_locale],
+                'LANGUAGE' => Chef::Config[:internal_locale],
+              },
             }).and_return(true)
             shell_out_obj.shell_out(cmd, options)
             expect(options[:environment].has_key?('LC_ALL')).to be false
@@ -155,13 +165,13 @@ describe Chef::Mixin::ShellOut do
 
         describe "and env is an option" do
           it "should not change env when set to nil" do
-            options = { :env => { 'LC_ALL' => nil } }
+            options = { :env => { 'LC_ALL' => nil, 'LANG' => nil, 'LANGUAGE' => nil } }
             expect(shell_out_obj).to receive(:shell_out_command).with(cmd, options).and_return(true)
             shell_out_obj.shell_out(cmd, options)
           end
 
           it "should not change env when set to non-nil" do
-            options = { :env => { 'LC_ALL' => 'de_DE.UTF-8'}}
+            options = { :env => { 'LC_ALL' => 'de_DE.UTF-8', 'LANG' => 'de_DE.UTF-8', 'LANGUAGE' => 'de_DE.UTF-8' }}
             expect(shell_out_obj).to receive(:shell_out_command).with(cmd, options).and_return(true)
             shell_out_obj.shell_out(cmd, options)
           end
@@ -169,7 +179,12 @@ describe Chef::Mixin::ShellOut do
           it "should set env['LC_ALL'] to 'en_US.UTF-8' when 'LC_ALL' not present" do
             options = { :env => { 'HOME' => '/Users/morty' } }
             expect(shell_out_obj).to receive(:shell_out_command).with(cmd, {
-              :env => { 'HOME' => '/Users/morty', 'LC_ALL' => Chef::Config[:internal_locale] },
+              :env => {
+                'HOME'     => '/Users/morty',
+                'LC_ALL'   => Chef::Config[:internal_locale],
+                'LANG'     => Chef::Config[:internal_locale],
+                'LANGUAGE' => Chef::Config[:internal_locale],
+              }
             }).and_return(true)
             shell_out_obj.shell_out(cmd, options)
           end
@@ -177,7 +192,12 @@ describe Chef::Mixin::ShellOut do
           it "should not mutate the options hash when it adds LC_ALL" do
             options = { :env => { 'HOME' => '/Users/morty' } }
             expect(shell_out_obj).to receive(:shell_out_command).with(cmd, {
-              :env => { 'HOME' => '/Users/morty', 'LC_ALL' => Chef::Config[:internal_locale] },
+              :env => {
+                'HOME'     => '/Users/morty',
+                'LC_ALL'   => Chef::Config[:internal_locale],
+                'LANG'     => Chef::Config[:internal_locale],
+                'LANGUAGE' => Chef::Config[:internal_locale],
+              }
             }).and_return(true)
             shell_out_obj.shell_out(cmd, options)
             expect(options[:env].has_key?('LC_ALL')).to be false
@@ -188,7 +208,12 @@ describe Chef::Mixin::ShellOut do
           it "should add environment option and set environment['LC_ALL'] to 'en_US.UTF_8'" do
             options = { :user => 'morty' }
             expect(shell_out_obj).to receive(:shell_out_command).with(cmd, {
-              :user => 'morty', :environment => { 'LC_ALL' => Chef::Config[:internal_locale] },
+              :user => 'morty',
+              :environment => {
+                'LC_ALL'   => Chef::Config[:internal_locale],
+                'LANG'     => Chef::Config[:internal_locale],
+                'LANGUAGE' => Chef::Config[:internal_locale],
+              },
             }).and_return(true)
             shell_out_obj.shell_out(cmd, options)
           end
@@ -198,7 +223,11 @@ describe Chef::Mixin::ShellOut do
       describe "when the last argument is not a Hash" do
         it "should add environment options and set environment['LC_ALL'] to 'en_US.UTF-8'" do
           expect(shell_out_obj).to receive(:shell_out_command).with(cmd, {
-            :environment => { 'LC_ALL' => Chef::Config[:internal_locale] },
+            :environment => {
+              'LC_ALL'   => Chef::Config[:internal_locale],
+              'LANG'     => Chef::Config[:internal_locale],
+              'LANGUAGE' => Chef::Config[:internal_locale],
+            },
           }).and_return(true)
           shell_out_obj.shell_out(cmd)
         end

--- a/spec/unit/mixin/shell_out_spec.rb
+++ b/spec/unit/mixin/shell_out_spec.rb
@@ -123,19 +123,19 @@ describe Chef::Mixin::ShellOut do
 
       describe "when the last argument is a Hash" do
         describe "and environment is an option" do
-          it "should not change environment['LC_ALL'] when set to nil" do
+          it "should not change environment language settings when they are set to nil" do
             options = { :environment => { 'LC_ALL' => nil, 'LANGUAGE' => nil, 'LANG' => nil } }
             expect(shell_out_obj).to receive(:shell_out_command).with(cmd, options).and_return(true)
             shell_out_obj.shell_out(cmd, options)
           end
 
-          it "should not change environment['LC_ALL'] when set to non-nil" do
+          it "should not change environment language settings when they are set to non-nil" do
             options = { :environment => { 'LC_ALL' => 'en_US.UTF-8', 'LANGUAGE' => 'en_US.UTF-8', 'LANG' => 'en_US.UTF-8' } }
             expect(shell_out_obj).to receive(:shell_out_command).with(cmd, options).and_return(true)
             shell_out_obj.shell_out(cmd, options)
           end
 
-          it "should set environment['LC_ALL'] to 'en_US.UTF-8' when 'LC_ALL' not present" do
+          it "should set environment language settings to the configured internal locale when they are not present" do
             options = { :environment => { 'HOME' => '/Users/morty' } }
             expect(shell_out_obj).to receive(:shell_out_command).with(cmd, {
               :environment => {
@@ -148,7 +148,7 @@ describe Chef::Mixin::ShellOut do
             shell_out_obj.shell_out(cmd, options)
           end
 
-          it "should not mutate the options hash when it adds LC_ALL" do
+          it "should not mutate the options hash when it adds language settings" do
             options = { :environment => { 'HOME' => '/Users/morty' } }
             expect(shell_out_obj).to receive(:shell_out_command).with(cmd, {
               :environment => {
@@ -164,19 +164,19 @@ describe Chef::Mixin::ShellOut do
         end
 
         describe "and env is an option" do
-          it "should not change env when set to nil" do
+          it "should not change env when langauge options are set to nil" do
             options = { :env => { 'LC_ALL' => nil, 'LANG' => nil, 'LANGUAGE' => nil } }
             expect(shell_out_obj).to receive(:shell_out_command).with(cmd, options).and_return(true)
             shell_out_obj.shell_out(cmd, options)
           end
 
-          it "should not change env when set to non-nil" do
+          it "should not change env when language options are set to non-nil" do
             options = { :env => { 'LC_ALL' => 'de_DE.UTF-8', 'LANG' => 'de_DE.UTF-8', 'LANGUAGE' => 'de_DE.UTF-8' }}
             expect(shell_out_obj).to receive(:shell_out_command).with(cmd, options).and_return(true)
             shell_out_obj.shell_out(cmd, options)
           end
 
-          it "should set env['LC_ALL'] to 'en_US.UTF-8' when 'LC_ALL' not present" do
+          it "should set environment language settings to the configured internal locale when they are not present" do
             options = { :env => { 'HOME' => '/Users/morty' } }
             expect(shell_out_obj).to receive(:shell_out_command).with(cmd, {
               :env => {
@@ -189,7 +189,7 @@ describe Chef::Mixin::ShellOut do
             shell_out_obj.shell_out(cmd, options)
           end
 
-          it "should not mutate the options hash when it adds LC_ALL" do
+          it "should not mutate the options hash when it adds language settings" do
             options = { :env => { 'HOME' => '/Users/morty' } }
             expect(shell_out_obj).to receive(:shell_out_command).with(cmd, {
               :env => {
@@ -205,7 +205,7 @@ describe Chef::Mixin::ShellOut do
         end
 
         describe "and no env/environment option is present" do
-          it "should add environment option and set environment['LC_ALL'] to 'en_US.UTF_8'" do
+          it "should set environment language settings to the configured internal locale" do
             options = { :user => 'morty' }
             expect(shell_out_obj).to receive(:shell_out_command).with(cmd, {
               :user => 'morty',
@@ -221,7 +221,7 @@ describe Chef::Mixin::ShellOut do
       end
 
       describe "when the last argument is not a Hash" do
-        it "should add environment options and set environment['LC_ALL'] to 'en_US.UTF-8'" do
+        it "should set environment language settings to the configured internal locale" do
           expect(shell_out_obj).to receive(:shell_out_command).with(cmd, {
             :environment => {
               'LC_ALL'   => Chef::Config[:internal_locale],


### PR DESCRIPTION
if we don't force LANGUAGE then package installs will still fail, etc
due to taking precedence over even LC_ALL, force LANG as well for
good measure which should cover all the bases hopefully.

fixes #2695 