### PR TITLE
add a compile_time flag to chef_gem resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * Added deprecation warnings around the use of command attribute in script resources
 * Audit mode feature added - see the RELEASE_NOTES for details
 * shell_out now sets `LANGUAGE` and `LANG` to the `Chef::Config[:internal_locale]` in addition to `LC_ALL` forcing
+* chef_gem supports a compile_time flag and will warn if it is not set (behavior will change in the future)
 
 ## 12.0.3
 * [**Phil Dibowitz**](https://github.com/jaymzh):

--- a/lib/chef/resource/chef_gem.rb
+++ b/lib/chef/resource/chef_gem.rb
@@ -28,6 +28,7 @@ class Chef
       def initialize(name, run_context=nil)
         super
         @resource_name = :chef_gem
+        @compile_time = nil
         @gem_binary = RbConfig::CONFIG['bindir'] + "/gem"
       end
 
@@ -40,13 +41,29 @@ class Chef
         @gem_binary
       end
 
+      def compile_time(arg=nil)
+        set_or_return(
+          :compile_time,
+          arg,
+          :kind_of => [ TrueClass, FalseClass ]
+        )
+      end
+
       def after_created
         # Chef::Resource.run_action: Caveat: this skips Chef::Runner.run_action, where notifications are handled
         # Action could be an array of symbols, but probably won't (think install + enable for a package)
-        Array(@action).each do |action|
-          self.run_action(action)
+        if compile_time.nil?
+          Chef::Log.warn "The chef_gem installation at compile time is deprecated and this behavior will change in the future."
+          Chef::Log.warn "Please set `compile_time false` on the resource to use the new behavior and suppress this warning,"
+          Chef::Log.warn "or you may set `compile_time true` on the resource if compile_time behavior is necessary."
         end
-        Gem.clear_paths
+
+        if compile_time || compile_time.nil?
+          Array(action).each do |action|
+            self.run_action(action)
+          end
+          Gem.clear_paths
+        end
       end
     end
   end

--- a/spec/unit/resource/chef_gem_spec.rb
+++ b/spec/unit/resource/chef_gem_spec.rb
@@ -32,16 +32,70 @@ describe Chef::Resource::ChefGem, "initialize" do
 end
 
 describe Chef::Resource::ChefGem, "gem_binary" do
+  let(:resource) { Chef::Resource::ChefGem.new("foo") }
+
   before(:each) do
     expect(RbConfig::CONFIG).to receive(:[]).with('bindir').and_return("/opt/chef/embedded/bin")
-    @resource = Chef::Resource::ChefGem.new("foo")
   end
 
   it "should raise an exception when gem_binary is set" do
-    expect { @resource.gem_binary("/lol/cats/gem") }.to raise_error(ArgumentError)
+    expect { resource.gem_binary("/lol/cats/gem") }.to raise_error(ArgumentError)
   end
 
   it "should set the gem_binary based on computing it from RbConfig" do
-    expect(@resource.gem_binary).to eql("/opt/chef/embedded/bin/gem")
+    expect(resource.gem_binary).to eql("/opt/chef/embedded/bin/gem")
+  end
+
+  it "should set the gem_binary based on computing it from RbConfig" do
+    expect(resource.compile_time).to be nil
+  end
+
+  context "when building the resource" do
+    let(:node) do
+      Chef::Node.new.tap {|n| n.normal[:tags] = [] }
+    end
+
+    let(:run_context) do
+      Chef::RunContext.new(node, {}, nil)
+    end
+
+    let(:recipe) do
+      Chef::Recipe.new("hjk", "test", run_context)
+    end
+
+    let(:resource) { Chef::Resource::ChefGem.new("foo", run_context) }
+
+    before do
+      expect(Chef::Resource::ChefGem).to receive(:new).and_return(resource)
+    end
+
+    it "runs the install at compile-time by default", :chef_lt_13_only do
+      expect(resource).to receive(:run_action).with(:install)
+      expect(Chef::Log).to receive(:warn).at_least(:once)
+      recipe.chef_gem "foo"
+    end
+
+    # the default behavior will change in Chef-13
+    it "does not runs the install at compile-time by default", :chef_gte_13_only do
+      expect(resource).not_to receive(:run_action).with(:install)
+      expect(Chef::Log).not_to receive(:warn)
+      recipe.chef_gem "foo"
+    end
+
+    it "compile_time true installs at compile-time" do
+      expect(resource).to receive(:run_action).with(:install)
+      expect(Chef::Log).not_to receive(:warn)
+      recipe.chef_gem "foo" do
+        compile_time true
+      end
+    end
+
+    it "compile_time false does not install at compile-time" do
+      expect(resource).not_to receive(:run_action).with(:install)
+      expect(Chef::Log).not_to receive(:warn)
+      recipe.chef_gem "foo" do
+        compile_time false
+      end
+    end
   end
 end


### PR DESCRIPTION
the default is still the same, but will warn that users should start
being explicit.  setting compile_time false will become the new
default in chef-13 and is encouraged to avoid the compile_time arms
race.