### PR TITLE
Update martinisoft to FreeBSD Lieutenant

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -113,6 +113,7 @@ The specific components of Chef related to a given platform - including (but not
 
 ### Lieutenant
 
+* [Aaron Kalin](https://github.com/martinisoft)
+
 ### Maintainers
 
-* [Aaron Kalin](https://github.com/martinisoft)


### PR DESCRIPTION
Per conversation today in #chef-hacking I am moving myself to the FreeBSD Lieutenants list to help guide decisions with FreeBSD releases.