### PR TITLE
deep_merge_cache fixes for bugs in 12.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * shell_out now sets `LANGUAGE` and `LANG` to the `Chef::Config[:internal_locale]` in addition to `LC_ALL` forcing
 * chef_gem supports a compile_time flag and will warn if it is not set (behavior will change in the future)
 * suppress 3694 warnings on the most trivial resource cloning
+* fixed bugs in the deep_merge_cache logic introduced in 12.0.0 around `node['foo']` vs `node[:foo]` vs. `node.foo`
 
 ## 12.0.3
 * [**Phil Dibowitz**](https://github.com/jaymzh):

--- a/lib/chef/node/attribute.rb
+++ b/lib/chef/node/attribute.rb
@@ -253,7 +253,7 @@ class Chef
          if path.nil?
            @deep_merge_cache = {}
          else
-           deep_merge_cache.delete(path)
+           deep_merge_cache.delete(path.to_s)
          end
        end
 
@@ -436,12 +436,12 @@ class Chef
        end
 
        def [](key)
-         if deep_merge_cache.has_key?(key)
+         if deep_merge_cache.has_key?(key.to_s)
            # return the cache of the deep merged values by top-level key
-           deep_merge_cache[key]
+           deep_merge_cache[key.to_s]
          else
            # save all the work of computing node[key]
-           deep_merge_cache[key] = merged_attributes(key)
+           deep_merge_cache[key.to_s] = merged_attributes(key)
          end
        end
 


### PR DESCRIPTION
In 12.0.0 we introduced a cache for the merged attributes for the
top-level node attribute keys.  This fixes this so that node['foo']
and node[:foo] are not cached separately.  This also showed up in bugs
as issues between node['foo'] access and node.foo access because
node.foo is translated into node[:foo].

fixes #2700 #2712 #2745